### PR TITLE
Use `browser.*` APIs when possible

### DIFF
--- a/lib/background.js
+++ b/lib/background.js
@@ -1,6 +1,8 @@
 /** Add this to background scripts */
 
-chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+const isChrome = typeof chrome !== 'undefined'
+
+;(isChrome ? chrome : browser).runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message && message.type === 'WTW_INJECT' && sender && sender.tab && sender.tab.id != null) {
     let file = message.file
     try {
@@ -11,7 +13,12 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
         frameId: sender.tab.frameId,
         file,
       }
-      chrome.tabs.executeScript(sender.tab.id, details, () => sendResponse())
+      const callback = () => sendResponse()
+      if (isChrome) {
+        chrome.tabs.executeScript(sender.tab.id, details, callback)
+      } else {
+        browser.tabs.executeScript(sender.tab.id, details).then(callback)
+      }
       return true
     }
   }

--- a/lib/background.js
+++ b/lib/background.js
@@ -1,8 +1,6 @@
 /** Add this to background scripts */
 
-const isChrome = typeof chrome !== 'undefined'
-
-;(isChrome ? chrome : browser).runtime.onMessage.addListener((message, sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message && message.type === 'WTW_INJECT' && sender && sender.tab && sender.tab.id != null) {
     let file = message.file
     try {
@@ -13,12 +11,7 @@ const isChrome = typeof chrome !== 'undefined'
         frameId: sender.tab.frameId,
         file,
       }
-      const callback = () => sendResponse()
-      if (isChrome) {
-        chrome.tabs.executeScript(sender.tab.id, details, callback)
-      } else {
-        browser.tabs.executeScript(sender.tab.id, details).then(callback)
-      }
+      chrome.tabs.executeScript(sender.tab.id, details, () => sendResponse())
       return true
     }
   }

--- a/lib/background.js
+++ b/lib/background.js
@@ -1,8 +1,8 @@
 /** Add this to background scripts */
 
-const isChrome = typeof chrome !== 'undefined'
+const hasBrowser = typeof browser !== 'undefined'
 
-;(isChrome ? chrome : browser).runtime.onMessage.addListener((message, sender, sendResponse) => {
+;(hasBrowser ? browser : chrome).runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message && message.type === 'WTW_INJECT' && sender && sender.tab && sender.tab.id != null) {
     let file = message.file
     try {
@@ -14,10 +14,10 @@ const isChrome = typeof chrome !== 'undefined'
         file,
       }
       const callback = () => sendResponse()
-      if (isChrome) {
-        chrome.tabs.executeScript(sender.tab.id, details, callback)
-      } else {
+      if (hasBrowser) {
         browser.tabs.executeScript(sender.tab.id, details).then(callback)
+      } else {
+        chrome.tabs.executeScript(sender.tab.id, details, callback)
       }
       return true
     }


### PR DESCRIPTION
https://github.com/crimx/webpack-target-webextension/blob/cbb1185e2e8935205a1f36d862bde80e1b96a3c3/lib/background.js#L3

- `chrome` is defined everywhere, so this piece of code has always used the `chrome.*` API
- There's no advantage in using the browser.* API in this case, it's still dealing with a callback

For this reason, I dropped the check and the duplicate code