### PR TITLE
Add support for injection in iframes

### DIFF
--- a/lib/background.js
+++ b/lib/background.js
@@ -10,7 +10,7 @@ const isChrome = typeof chrome !== 'undefined'
     } catch {}
     if (file) {
       const details = {
-        frameId: sender.tab.frameId,
+        frameId: sender.frameId,
         file,
       }
       const callback = () => sendResponse()


### PR DESCRIPTION
Fixes #15 

`Tab#frameId` does not exist: https://developer.chrome.com/docs/extensions/reference/tabs/#type-Tab

But `Sender#frameId` does: https://developer.chrome.com/docs/extensions/reference/runtime/#type-MessageSender